### PR TITLE
Fixing matic production deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@ Subgraph for Decentralized Grants
 ## Install Dependencies
 `$ yarn`
 
+To install dev dependencies
+
+`$ yarn install -D`
+
 ## Deploy to matic/rinkeby
 1) Update any contract details in `config/*` and prepare the `subgraph.yaml`
 `$ yarn prepare:[matic|rinkeby]`
 2) Generate the types
 `$ yarn codegen && yarn build`
-4) Deploy the subgraph to public graph node
-`$ yarn deploy`
+4) Deploy the subgraph to public graph node on the appropriate network
+`$ yarn deploy:[matic]`
 
 
 ## Run Local Environment

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ To install dev dependencies
 `$ yarn prepare:[matic|rinkeby]`
 2) Generate the types
 `$ yarn codegen && yarn build`
+4) Authenticate with TheGraph if you have not already
+`$ yarn graph auth https://api.thegraph.com/deploy/ [access token]`
 4) Deploy the subgraph to public graph node on the appropriate network
 `$ yarn deploy:[matic]`
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare:matic": "mustache config/matic.json subgraph.template.yaml > subgraph.yaml",
     "prepare:rinkeby": "mustache config/rinkeby.json subgraph.template.yaml > subgraph.yaml",
     "deploy:matic": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ dcgtc/dc-gitcoin-grants-matic",
+    "deploy:rinkeby": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ dcgtc/dc-gitcoin-grants-rinkeby",
     "create-local": "graph create --node http://localhost:8020/ dcgtc/dgrants-subgraph",
     "remove-local": "graph remove --node http://localhost:8020/ dcgtc/dgrants-subgraph",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 dcgtc/dcgrants-subgraph"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dgrants",
+  "name": "dgrants-subgraph",
   "license": "UNLICENSED",
   "scripts": {
     "lint": "eslint --ext .ts --ext .js --ext .json",
@@ -9,10 +9,10 @@
     "build": "graph build",
     "prepare:matic": "mustache config/matic.json subgraph.template.yaml > subgraph.yaml",
     "prepare:rinkeby": "mustache config/rinkeby.json subgraph.template.yaml > subgraph.yaml",
-    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ gitcoinco/dgrants",
-    "create-local": "graph create --node http://localhost:8020/ gitcoinco/dgrants",
-    "remove-local": "graph remove --node http://localhost:8020/ gitcoinco/dgrants",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 gitcoinco/dgrants"
+    "deploy:matic": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ dcgtc/dc-gitcoin-grants-matic",
+    "create-local": "graph create --node http://localhost:8020/ dcgtc/dgrants-subgraph",
+    "remove-local": "graph remove --node http://localhost:8020/ dcgtc/dgrants-subgraph",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 dcgtc/dcgrants-subgraph"
   },
   "dependencies": {
     "@graphprotocol/graph-ts": "^0.22.0-alpha.3"


### PR DESCRIPTION
Updating the yarn commands in package.json to deploy to the hosted version of TheGraph as the decentralized version does not yet support Polygon.