### PR TITLE
fix: adds `metaPtr` as an `Entity`

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,8 +1,14 @@
+type MetaPtr @entity {
+  id: ID!
+  protocol: BigInt!
+  pointer: String!
+}
+
 type Grant @entity {
   id: ID!
   owner: Bytes!
   payee: Bytes!
-  metaPtr: String!
+  metaPtr: MetaPtr!
   lastUpdatedBlockNumber: BigInt!
   lastUpdatedTimestamp: BigInt!
   createdAtTimestamp: BigInt!

--- a/src/grantRegistry.ts
+++ b/src/grantRegistry.ts
@@ -18,6 +18,10 @@ export function handleGrantCreated(event: GrantCreated): void {
     if (metaPtr == null) {
         metaPtr = new MetaPtr(event.params.id.toHex())
     }
+    
+    // Entity fields can be set based on event parameters
+    metaPtr.protocol = event.params.metaPtr.protocol
+    metaPtr.pointer = event.params.metaPtr.pointer
 
     // Entity fields can be set based on event parameters
     entity.id = event.params.id.toHex()
@@ -48,6 +52,10 @@ export function handleGrantUpdated(event: GrantUpdated): void {
         metaPtr = new MetaPtr(event.params.id.toHex())
     }
 
+    // Entity fields can be set based on event parameters
+    metaPtr.protocol = event.params.metaPtr.protocol
+    metaPtr.pointer = event.params.metaPtr.pointer
+    
     // Entity fields can be set based on event parameters
     entity.id = event.params.id.toHex()
     entity.metaPtr = metaPtr.id

--- a/src/grantRegistry.ts
+++ b/src/grantRegistry.ts
@@ -2,27 +2,28 @@ import {
   GrantCreated,
   GrantUpdated
 } from "../generated/GrantRegistry/GrantRegistry"
-import { Grant } from "../generated/schema"
+import { Grant, MetaPtr } from "../generated/schema"
 
 export function handleGrantCreated(event: GrantCreated): void {
     // Entities can be loaded from the store using a string ID; this ID
     // needs to be unique across all entities of the same type
     let entity = Grant.load(event.params.id.toHex())
+    let metaPtr = MetaPtr.load(event.params.id.toHex())
 
     // Entities only exist after they have been saved to the store;
     // `null` checks allow to create entities on demand
     if (entity == null) {
         entity = new Grant(event.params.id.toHex())
     }
+    if (metaPtr == null) {
+        metaPtr = new MetaPtr(event.params.id.toHex())
+    }
 
     // Entity fields can be set based on event parameters
     entity.id = event.params.id.toHex()
+    entity.metaPtr = metaPtr.id
     entity.owner = event.params.owner
     entity.payee = event.params.payee
-
-    const metaPtr = event.params.metaPtr
-    entity.metaPtr = [metaPtr.protocol.toString(), metaPtr.pointer].join('-')
-
     entity.lastUpdatedBlockNumber = event.block.number
     entity.lastUpdatedTimestamp = event.block.timestamp
     entity.createdAtTimestamp =
@@ -36,21 +37,22 @@ export function handleGrantUpdated(event: GrantUpdated): void {
     // Entities can be loaded from the store using a string ID; this ID
     // needs to be unique across all entities of the same type
     let entity = Grant.load(event.params.id.toHex())
+    let metaPtr = MetaPtr.load(event.params.id.toHex())
 
     // Entities only exist after they have been saved to the store;
     // `null` checks allow to create entities on demand
     if (entity == null) {
         entity = new Grant(event.params.id.toHex())
     }
+    if (metaPtr == null) {
+        metaPtr = new MetaPtr(event.params.id.toHex())
+    }
 
     // Entity fields can be set based on event parameters
     entity.id = event.params.id.toHex()
+    entity.metaPtr = metaPtr.id
     entity.owner = event.params.owner
     entity.payee = event.params.payee
-
-    const metaPtr = event.params.metaPtr
-    entity.metaPtr = [metaPtr.protocol.toString(), metaPtr.pointer].join('-')
-
     entity.lastUpdatedBlockNumber = event.block.number
     entity.lastUpdatedTimestamp = event.block.timestamp
     entity.createdAtTimestamp =


### PR DESCRIPTION
This PR correctly stores the `metaPtr` as an `Entity` rather than a `string`.