### PR TITLE
fix: ensure `createdAtTimestamp` and `metaPtr` details are `save`d correctly

### DIFF
--- a/src/grantRegistry.ts
+++ b/src/grantRegistry.ts
@@ -21,8 +21,11 @@ export function handleGrantCreated(event: GrantCreated): void {
     }
     
     // Entity fields can be set based on event parameters
-    metaPtr.protocol = event.params.metaPtr.protocol
-    metaPtr.pointer = event.params.metaPtr.pointer
+    metaPtr.protocol = event.params.metaPtr.protocol || new BigInt(0)
+    metaPtr.pointer = event.params.metaPtr.pointer || ''
+    
+    // Entities can be written to the store with `.save()`
+    metaPtr.save()
 
     // Entity fields can be set based on event parameters
     entity.id = event.params.id.toHex()
@@ -54,9 +57,12 @@ export function handleGrantUpdated(event: GrantUpdated): void {
     }
 
     // Entity fields can be set based on event parameters
-    metaPtr.protocol = event.params.metaPtr.protocol
-    metaPtr.pointer = event.params.metaPtr.pointer
-    
+    metaPtr.protocol = event.params.metaPtr.protocol || new BigInt(0)
+    metaPtr.pointer = event.params.metaPtr.pointer || ''
+
+    // Entities can be written to the store with `.save()`
+    metaPtr.save()
+
     // Entity fields can be set based on event parameters
     entity.id = event.params.id.toHex()
     entity.metaPtr = metaPtr.id

--- a/src/grantRegistry.ts
+++ b/src/grantRegistry.ts
@@ -1,3 +1,4 @@
+import { BigInt } from "@graphprotocol/graph-ts"
 import {
   GrantCreated,
   GrantUpdated
@@ -31,7 +32,7 @@ export function handleGrantCreated(event: GrantCreated): void {
     entity.lastUpdatedBlockNumber = event.block.number
     entity.lastUpdatedTimestamp = event.block.timestamp
     entity.createdAtTimestamp =
-        entity.createdAtTimestamp.toString() !== "0" ? entity.createdAtTimestamp : event.block.timestamp
+        entity.createdAtTimestamp != new BigInt(0) ? entity.createdAtTimestamp : event.block.timestamp
 
     // Entities can be written to the store with `.save()`
     entity.save()
@@ -64,7 +65,7 @@ export function handleGrantUpdated(event: GrantUpdated): void {
     entity.lastUpdatedBlockNumber = event.block.number
     entity.lastUpdatedTimestamp = event.block.timestamp
     entity.createdAtTimestamp =
-        entity.createdAtTimestamp.toString() !== "0" ? entity.createdAtTimestamp : event.block.timestamp
+        entity.createdAtTimestamp != new BigInt(0) ? entity.createdAtTimestamp : event.block.timestamp
 
     // Entities can be written to the store with `.save()`
     entity.save()

--- a/src/grantRoundManager.ts
+++ b/src/grantRoundManager.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, Bytes } from "@graphprotocol/graph-ts"
+import { Address, BigDecimal, BigInt, Bytes } from "@graphprotocol/graph-ts"
 import {
     GrantDonation as GrantDonationFilter,
     GrantRoundCreated as GrantRoundCreatedFilter,
@@ -27,7 +27,7 @@ import { GrantDonation, GrantRound } from "../generated/schema"
     entity.lastUpdatedBlockNumber = event.block.number
     entity.lastUpdatedTimestamp = event.block.timestamp
     entity.createdAtTimestamp = 
-        entity.createdAtTimestamp.toString() !== "0" ? entity.createdAtTimestamp : event.block.timestamp
+        entity.createdAtTimestamp != new BigInt(0) ? entity.createdAtTimestamp : event.block.timestamp
 
     // Entities can be written to the store with `.save()`
     entity.save()
@@ -50,7 +50,7 @@ import { GrantDonation, GrantRound } from "../generated/schema"
     entity.lastUpdatedBlockNumber = event.block.number
     entity.lastUpdatedTimestamp = event.block.timestamp
     entity.createdAtTimestamp = 
-        entity.createdAtTimestamp.toString() !== "0" ? entity.createdAtTimestamp : event.block.timestamp
+        entity.createdAtTimestamp != new BigInt(0) ? entity.createdAtTimestamp : event.block.timestamp
 
     // Entities can be written to the store with `.save()`
     entity.save()


### PR DESCRIPTION
This PR ensures that the `createdAtTimestamps` are correctly recorded against the entities.

--

I have published this to the graph so that I could test #531