### PR TITLE
fix: ensures transaction.hash is hexed before assigning to ID

### DIFF
--- a/src/grantRoundManager.ts
+++ b/src/grantRoundManager.ts
@@ -5,19 +5,19 @@ import {
 } from "../generated/GrantRoundManager/GrantRoundManager"
 import { GrantDonation, GrantRound } from "../generated/schema"
 
-  export function handleGrantDonation(event: GrantDonationFilter): void {
+export function handleGrantDonation(event: GrantDonationFilter): void {
     // Entities can be loaded from the store using a string ID; this ID
     // needs to be unique across all entities of the same type
-    let entity = GrantDonation.load(`${event.transaction.hash}-${event.params.grantId.toHex()}`)
+    let entity = GrantDonation.load(`${event.transaction.hash.toHex()}-${event.params.grantId.toHex()}`)
 
     // Entities only exist after they have been saved to the store;
     // `null` checks allow to create entities on demand
     if (entity == null) {
-        entity = new GrantDonation(`${event.transaction.hash}-${event.params.grantId.toHex()}`)
+        entity = new GrantDonation(`${event.transaction.hash.toHex()}-${event.params.grantId.toHex()}`)
     }
 
     // Entity fields can be set based on event parameters
-    entity.id = `${event.transaction.hash}-${event.params.grantId.toHex()}`
+    entity.id = `${event.transaction.hash.toHex()}-${event.params.grantId.toHex()}`
     entity.grantId = event.params.grantId
     entity.donationAmount = new BigDecimal(event.params.donationAmount)
     entity.tokenIn = event.params.tokenIn
@@ -31,9 +31,9 @@ import { GrantDonation, GrantRound } from "../generated/schema"
 
     // Entities can be written to the store with `.save()`
     entity.save()
-  }
+}
 
-  export function handleGrantRoundCreated(event: GrantRoundCreatedFilter): void {
+export function handleGrantRoundCreated(event: GrantRoundCreatedFilter): void {
     // Entities can be loaded from the store using a string ID; this ID
     // needs to be unique across all entities of the same type
     let entity = GrantRound.load(event.params.grantRound.toHex())


### PR DESCRIPTION
This PR fixes the `dGrants` -> `recursiveGraphFetch` method by properly hexing the ID so that it can be used in the query filter.

--

These changes have already been published