### PR TITLE
feat: adds GrantRoundDonations entity sourced from GrantRounds

### DIFF
--- a/abis/GrantRound.json
+++ b/abis/GrantRound.json
@@ -1,0 +1,321 @@
+[
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_metadataAdmin",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_payoutAdmin",
+          "type": "address"
+        },
+        {
+          "internalType": "contract GrantRegistry",
+          "name": "_registry",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "_donationToken",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "_matchingToken",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_startTime",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_endTime",
+          "type": "uint256"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "protocol",
+              "type": "uint256"
+            },
+            {
+              "internalType": "string",
+              "name": "pointer",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct MetaPtr",
+          "name": "_metaPtr",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "contributor",
+          "type": "address"
+        }
+      ],
+      "name": "AddMatchingFunds",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "protocol",
+              "type": "uint256"
+            },
+            {
+              "internalType": "string",
+              "name": "pointer",
+              "type": "string"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct MetaPtr",
+          "name": "oldMetaPtr",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "protocol",
+              "type": "uint256"
+            },
+            {
+              "internalType": "string",
+              "name": "pointer",
+              "type": "string"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct MetaPtr",
+          "name": "newMetaPtr",
+          "type": "tuple"
+        }
+      ],
+      "name": "MetadataUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "PaidOutGrants",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "addMatchingFunds",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "donationToken",
+      "outputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endTime",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "hasPaidOut",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isActive",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "matchingToken",
+      "outputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "metaPtr",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "protocol",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "pointer",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "metadataAdmin",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "payoutAdmin",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_payoutAddress",
+          "type": "address"
+        }
+      ],
+      "name": "payoutGrants",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "registry",
+      "outputs": [
+        {
+          "internalType": "contract GrantRegistry",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "startTime",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "protocol",
+              "type": "uint256"
+            },
+            {
+              "internalType": "string",
+              "name": "pointer",
+              "type": "string"
+            }
+          ],
+          "internalType": "struct MetaPtr",
+          "name": "_newMetaPtr",
+          "type": "tuple"
+        }
+      ],
+      "name": "updateMetadataPtr",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]

--- a/schema.graphql
+++ b/schema.graphql
@@ -34,3 +34,14 @@ type GrantDonation @entity {
   lastUpdatedTimestamp: BigInt!
   createdAtTimestamp: BigInt!
 }
+
+type GrantRoundDonation @entity {
+  id: ID!
+  round: Bytes!
+  contributor: Bytes!
+  amount: BigInt!
+  hash: Bytes!
+  lastUpdatedBlockNumber: BigInt!
+  lastUpdatedTimestamp: BigInt!
+  createdAtTimestamp: BigInt!
+}

--- a/src/grantRound.ts
+++ b/src/grantRound.ts
@@ -1,0 +1,31 @@
+import { BigInt, dataSource } from "@graphprotocol/graph-ts"
+import { AddMatchingFunds } from "../generated/templates/GrantRound/GrantRound"
+import { GrantRoundDonation } from "../generated/schema"
+
+export function handleAddMatchingFunds(event: AddMatchingFunds): void {
+    // extract the grantRounds context
+    const context = dataSource.context()
+
+    // extract the GrantRound address from the context used to create the GrantRound template
+    const address = context.getBytes("address")
+
+    // Entities can be loaded from the store using a string ID; this ID
+    // needs to be unique across all entities of the same type
+    const entity = new GrantRoundDonation(event.transaction.hash.toHex())
+
+    // Entity fields can be set based on event parameters
+    entity.id = event.transaction.hash.toHex()
+    entity.round = address
+    entity.contributor = event.params.contributor
+    entity.amount = event.params.amount
+    entity.hash = event.transaction.hash
+    entity.lastUpdatedBlockNumber = event.block.number
+    entity.lastUpdatedTimestamp = event.block.timestamp
+    entity.createdAtTimestamp = 
+        entity.createdAtTimestamp != new BigInt(0) ? entity.createdAtTimestamp : event.block.timestamp
+
+    // Entities can be written to the store with `.save()`
+    entity.save()
+}
+
+

--- a/src/grantRoundManager.ts
+++ b/src/grantRoundManager.ts
@@ -1,9 +1,10 @@
-import { Address, BigDecimal, BigInt, Bytes } from "@graphprotocol/graph-ts"
+import { Address, BigDecimal, BigInt, Bytes, DataSourceContext } from "@graphprotocol/graph-ts"
 import {
     GrantDonation as GrantDonationFilter,
     GrantRoundCreated as GrantRoundCreatedFilter,
 } from "../generated/GrantRoundManager/GrantRoundManager"
 import { GrantDonation, GrantRound } from "../generated/schema"
+import { GrantRound as GrantRoundTemplate } from '../generated/templates'
 
 export function handleGrantDonation(event: GrantDonationFilter): void {
     // Entities can be loaded from the store using a string ID; this ID
@@ -34,6 +35,13 @@ export function handleGrantDonation(event: GrantDonationFilter): void {
 }
 
 export function handleGrantRoundCreated(event: GrantRoundCreatedFilter): void {
+    // Create a dataSource context to share with the GrantRoundTemplate
+    const context = new DataSourceContext()
+    // attach the GrantRound address to the context to associate with the donations
+    context.setBytes("address", event.params.grantRound)
+    // create the GrantRound and start listening for events
+    GrantRoundTemplate.createWithContext(event.params.grantRound, context)
+
     // Entities can be loaded from the store using a string ID; this ID
     // needs to be unique across all entities of the same type
     let entity = GrantRound.load(event.params.grantRound.toHex())

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -59,7 +59,6 @@ templates:
       language: wasm/assemblyscript
       file: ./src/grantRound.ts
       entities:
-        - GrantRound
         - GrantRoundDonation
       abis:
         - name: GrantRound

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -24,7 +24,6 @@ dataSources:
         - event: GrantUpdated(indexed uint96,indexed address,indexed address,(uint256,string),uint256)
           handler: handleGrantUpdated
       file: ./src/grantRegistry.ts
-
   - kind: ethereum/contract
     name: GrantRoundManager
     network: {{ network }}
@@ -48,3 +47,23 @@ dataSources:
         - event: GrantDonation(indexed uint96,indexed address,uint256,address[],uint256)
           handler: handleGrantDonation
       file: ./src/grantRoundManager.ts
+templates:
+  - kind: ethereum/contract
+    name: GrantRound
+    network: {{ network }}
+    source:
+      abi: GrantRound
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/grantRound.ts
+      entities:
+        - GrantRound
+        - GrantRoundDonation
+      abis:
+        - name: GrantRound
+          file: ./abis/GrantRound.json
+      eventHandlers:
+        - event: AddMatchingFunds(uint256,indexed address)
+          handler: handleAddMatchingFunds


### PR DESCRIPTION
This PR adds the `GrantRound` as a template so that we can watch events that are emitted from the `GrantRounds` that are created via the `GrantRoundManager`. This PR also adds `GrantRoundDonations` as an entity to retrieve all contributions sent to a specific round.

--

Relates to https://github.com/dcgtc/dgrants/issues/322#issuecomment-988965316

--

A deployed example of this subgraph can be found here: https://thegraph.com/hosted-service/subgraph/gdixon/dgrants-graph-rinkeby?version=current